### PR TITLE
Specify defaultValue as a PropType

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,10 @@ class Autocomplete extends Component {
      */
     data: PropTypes.array,
     /**
+     * Allow an optional default value for the TextInput.
+     */
+    defaultValue: PropTypes.string,
+    /**
      * Set to `true` to hide the suggestion list.
      */
     hideResults: PropTypes.bool,


### PR DESCRIPTION
This package is used by the AutocompleteInput component in instawork/core-mobile. Seeing warnings in the applicant app because defaultValue is not specified as a PropType.

<img width="375" alt="screen shot 2017-08-14 at 4 30 27 pm" src="https://user-images.githubusercontent.com/4325329/29296277-1e69ec54-810e-11e7-96de-2f3f5fa9589f.png">

